### PR TITLE
Add Zod validation to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ $ pnpm scrum add-employee
 
 社員を2名以上登録すると、`create-team` コマンドでスクラムチームを作成できます。
 
+### API
+
+Hono を使った API サーバーでも同じユースケースを利用できます。
+各エンドポイントでは zod を用いてリクエストをバリデートしています。
+
+```bash
+$ cd apps/api/
+$ pnpm build && pnpm start
+```
+
 ### Web
 
 > [!NOTE]  

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@panda-project/api",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "node ../../packages/config/build.mjs",
+    "build": "esbuild src/index.ts --bundle --outfile=dist/index.js --platform=node --format=esm",
+    "start": "node dist/index.js",
+    "type-check": "tspc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^3.11.0",
+    "@panda-project/gateway": "workspace:*",
+    "@panda-project/use-case": "workspace:*",
+    "zod": "^3.25.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.2",
+    "@panda-project/config": "workspace:*"
+  },
+  "license": "MIT"
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,14 +10,15 @@
     "type-check": "tspc --noEmit"
   },
   "dependencies": {
-    "hono": "^3.11.0",
     "@panda-project/gateway": "workspace:*",
     "@panda-project/use-case": "workspace:*",
+    "hono": "^3.11.0",
     "zod": "^3.25.8"
   },
   "devDependencies": {
-    "@types/node": "^20.8.2",
-    "@panda-project/config": "workspace:*"
+    "@hono/node-server": "^1.14.3",
+    "@panda-project/config": "workspace:*",
+    "@types/node": "^20.8.2"
   },
   "license": "MIT"
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,180 @@
+import { Hono } from 'hono'
+import { serve } from '@hono/node-server'
+import { z } from 'zod'
+
+import {
+  CreateEmployeeWebCommand,
+  EditEmployeeWebCommand,
+  RemoveEmployeeWebCommand,
+  InitWebCommand,
+  CreateScrumTeamWebCommand,
+  EditScrumTeamWebCommand,
+  DisbandScrumTeamWebCommand,
+} from '@panda-project/gateway'
+
+import {
+  EmployeeUseCase,
+  InitScenario,
+  ScrumTeamUseCase,
+} from '@panda-project/use-case'
+
+const app = new Hono()
+
+app.post('/init', async (c) => {
+  const schema = z.object({
+    productName: z
+      .string()
+      .min(1)
+      .max(30)
+      .regex(/^[a-zA-Z0-9_-]*$/),
+    projectName: z
+      .string()
+      .min(1)
+      .max(30)
+      .regex(/^[a-zA-Z0-9_-]*$/),
+  })
+
+  try {
+    const { productName, projectName } = schema.parse(await c.req.json())
+    const command = new InitWebCommand(productName, projectName)
+    await new InitScenario().exec(command)
+    return c.json({ message: 'ok' })
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return c.json({ errors: e.formErrors.fieldErrors }, 400)
+    }
+    throw e
+  }
+})
+
+app.post('/employees', async (c) => {
+  const schema = z.object({
+    familyName: z.string().min(1),
+    firstName: z.string().min(1),
+  })
+
+  try {
+    const { familyName, firstName } = schema.parse(await c.req.json())
+    const command = new CreateEmployeeWebCommand(familyName, firstName)
+    await new EmployeeUseCase().create(command)
+    return c.json({ message: 'ok' })
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return c.json({ errors: e.formErrors.fieldErrors }, 400)
+    }
+    throw e
+  }
+})
+
+app.put('/employees/:id', async (c) => {
+  const body = await c.req.json()
+  const schema = z.object({
+    familyName: z.string().min(1),
+    firstName: z.string().min(1),
+  })
+
+  try {
+    const { familyName, firstName } = schema.parse(body)
+    const id = Number.parseInt(c.req.param('id'), 10)
+    const command = new EditEmployeeWebCommand(id, familyName, firstName)
+    await new EmployeeUseCase().edit(command)
+    return c.json({ message: 'ok' })
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return c.json({ errors: e.formErrors.fieldErrors }, 400)
+    }
+    throw e
+  }
+})
+
+app.delete('/employees/:id', async (c) => {
+  const schema = z.object({ id: z.string().regex(/^\d+$/) })
+  try {
+    const { id } = schema.parse({ id: c.req.param('id') })
+    const command = new RemoveEmployeeWebCommand(Number.parseInt(id, 10))
+    await new EmployeeUseCase().remove(command)
+    return c.json({ message: 'ok' })
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return c.json({ errors: e.formErrors.fieldErrors }, 400)
+    }
+    throw e
+  }
+})
+
+app.post('/team', async (c) => {
+  const schema = z.object({
+    productOwnerId: z.string(),
+    scrumMasterId: z.string(),
+    developerIds: z.array(z.string()).min(0).max(10),
+  })
+
+  try {
+    const { productOwnerId, scrumMasterId, developerIds } = schema.parse(
+      await c.req.json()
+    )
+    const command = new CreateScrumTeamWebCommand(
+      productOwnerId,
+      scrumMasterId,
+      developerIds
+    )
+    await new ScrumTeamUseCase().create(command)
+    return c.json({ message: 'ok' })
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return c.json({ errors: e.formErrors.fieldErrors }, 400)
+    }
+    throw e
+  }
+})
+
+app.put('/team', async (c) => {
+  const schema = z.object({
+    productOwnerId: z.string(),
+    scrumMasterId: z.string(),
+    developerIds: z.array(z.string()).min(0).max(10),
+  })
+
+  try {
+    const { productOwnerId, scrumMasterId, developerIds } = schema.parse(
+      await c.req.json()
+    )
+    const command = new EditScrumTeamWebCommand(
+      productOwnerId,
+      scrumMasterId,
+      developerIds
+    )
+    await new ScrumTeamUseCase().edit(command)
+    return c.json({ message: 'ok' })
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return c.json({ errors: e.formErrors.fieldErrors }, 400)
+    }
+    throw e
+  }
+})
+
+app.delete('/team/:id', async (c) => {
+  const schema = z.object({ id: z.string().regex(/^\d+$/) })
+
+  try {
+    const { id } = schema.parse({ id: c.req.param('id') })
+    const command = new DisbandScrumTeamWebCommand(id)
+    await new ScrumTeamUseCase().disband(command)
+    return c.json({ message: 'ok' })
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return c.json({ errors: e.formErrors.fieldErrors }, 400)
+    }
+    throw e
+  }
+})
+
+app.onError((err, c) => {
+  return c.json({ error: err.message }, 500)
+})
+
+const port = 8787
+console.log(`Listening on http://localhost:${port}`)
+serve({ fetch: app.fetch, port })
+

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@panda-project/config/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"],
+      "@/*": ["../../packages/use-case/src/*"]
+    },
+    "outDir": "./dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/config/base.json
+++ b/packages/config/base.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "lib": ["es2022"],
-    "module": "commonjs",
+    "module": "ESNext",
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,

--- a/packages/gateway/src/external/lowdb/database.ts
+++ b/packages/gateway/src/external/lowdb/database.ts
@@ -10,12 +10,14 @@ const isTest = process.env.NODE_ENV === 'test'
 const dirname = isTest ? '/mock/path' : __dirname
 const cliPathIndex = dirname.indexOf('/apps/cli')
 const webPathIndex = dirname.indexOf('/apps/web')
+const apiPathIndex = dirname.indexOf('/apps/api')
 
-if (cliPathIndex === -1 && webPathIndex === -1 && !isTest) {
+if (cliPathIndex === -1 && webPathIndex === -1 && apiPathIndex === -1 && !isTest) {
   throw new Error('DB path not found')
 }
 
-const rootIndex = cliPathIndex > 0 ? cliPathIndex : webPathIndex
+const rootIndex =
+  cliPathIndex > 0 ? cliPathIndex : webPathIndex > 0 ? webPathIndex : apiPathIndex
 const basePath = dirname.slice(0, rootIndex)
 const dbFilePath = `${basePath}/db.json`
 

--- a/packages/gateway/src/external/lowdb/database.ts
+++ b/packages/gateway/src/external/lowdb/database.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname as pathDirname } from 'node:path'
 
 import { Adapter, Low, Memory } from 'lowdb'
 import { JSONFile } from 'lowdb/node'
@@ -7,7 +9,7 @@ import { DataBase, createDefaultData } from './schema'
 
 const isTest = process.env.NODE_ENV === 'test'
 
-const dirname = isTest ? '/mock/path' : __dirname
+const dirname = isTest ? '/mock/path' : pathDirname(fileURLToPath(import.meta.url))
 const cliPathIndex = dirname.indexOf('/apps/cli')
 const webPathIndex = dirname.indexOf('/apps/web')
 const apiPathIndex = dirname.indexOf('/apps/api')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,31 @@ importers:
         specifier: ^3.4.6
         version: 3.5.5(typescript@5.8.3)
 
+  apps/api:
+    dependencies:
+      '@panda-project/gateway':
+        specifier: workspace:*
+        version: link:../../packages/gateway
+      '@panda-project/use-case':
+        specifier: workspace:*
+        version: link:../../packages/use-case
+      hono:
+        specifier: ^3.11.0
+        version: 3.12.12
+      zod:
+        specifier: ^3.25.8
+        version: 3.25.8
+    devDependencies:
+      '@hono/node-server':
+        specifier: ^1.14.3
+        version: 1.14.3(hono@3.12.12)
+      '@panda-project/config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@types/node':
+        specifier: ^20.8.2
+        version: 20.17.50
+
   apps/cli:
     dependencies:
       '@inquirer/prompts':
@@ -531,9 +556,16 @@ packages:
     peerDependencies:
       react: '>= 16 || ^19.0.0-rc'
 
+  '@hono/node-server@1.14.3':
+    resolution: {integrity: sha512-KuDMwwghtFYSmIpr4WrKs1VpelTrptvJ+6x6mbUcZnFcc213cumTF5BdqfHyW93B19TNI4Vaev14vOI2a0Ie3w==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -541,6 +573,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@inquirer/checkbox@1.5.2':
     resolution: {integrity: sha512-CifrkgQjDkUkWexmgYYNyB5603HhTHI91vLFeQXh6qrTKiCMVASol01Rs1cv6LP/A2WccZSRlJKZhbaBIs/9ZA==}
@@ -899,6 +932,7 @@ packages:
 
   '@types/commander@2.12.5':
     resolution: {integrity: sha512-YXGZ/rz+s57VbzcvEV9fUoXeJlBt5HaKu5iUheiIWNsJs23bz6AnRuRiZBRVBLYyPnixNvVnuzM5pSaxr8Yp/g==}
+    deprecated: This is a stub types definition. commander provides its own type definitions, so you do not need this installed.
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -1663,6 +1697,7 @@ packages:
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:
@@ -1834,9 +1869,11 @@ packages:
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-prefix@4.0.0:
     resolution: {integrity: sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==}
@@ -1895,6 +1932,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hono@3.12.12:
+    resolution: {integrity: sha512-5IAMJOXfpA5nT+K0MNjClchzz0IhBHs2Szl7WFAhrFOsbtQsYmNynFyJRg/a3IPsmCfxcrf8txUGiNShXpK5Rg==}
+    engines: {node: '>=16.0.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1925,6 +1966,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2721,6 +2763,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   run-async@3.0.0:
@@ -3476,6 +3519,10 @@ snapshots:
   '@heroicons/react@2.2.0(react@18.2.0)':
     dependencies:
       react: 18.2.0
+
+  '@hono/node-server@1.14.3(hono@3.12.12)':
+    dependencies:
+      hono: 3.12.12
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -5166,6 +5213,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hono@3.12.12: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## Summary
- add zod dependency to API package
- validate incoming requests in API endpoints
- document API validation

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm type-check` *(fails: turbo not found)*
- `pnpm -r jest` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c033dc448324a6ceda18b1ac8af2